### PR TITLE
add number constraint for samples per MotionEvent

### DIFF
--- a/include/input/Input.h
+++ b/include/input/Input.h
@@ -111,6 +111,11 @@ enum {
 #define MAX_POINTERS 16
 
 /*
+ * Maximum number of samples supported per motion event.
+ */
+#define MAX_SAMPLES UINT16_MAX
+
+/*
  * Maximum pointer id value supported in a motion event.
  * Smallest pointer id is 0.
  * (This is limited by our use of BitSet32 to track pointer assignments.)

--- a/libs/input/Input.cpp
+++ b/libs/input/Input.cpp
@@ -421,7 +421,8 @@ void MotionEvent::transform(const float matrix[9]) {
 status_t MotionEvent::readFromParcel(Parcel* parcel) {
     size_t pointerCount = parcel->readInt32();
     size_t sampleCount = parcel->readInt32();
-    if (pointerCount == 0 || pointerCount > MAX_POINTERS || sampleCount == 0) {
+    if (pointerCount == 0 || pointerCount > MAX_POINTERS ||
+            sampleCount == 0 || sampleCount > MAX_SAMPLES) {
         return BAD_VALUE;
     }
 


### PR DESCRIPTION
Ticket: CYNGNOS-1299
Bug:23905002

Signed-off-by: Adam Lesinski adamlesinski@google.com

(cherry picked from commit 552a8a5d8df32f659b8d11311a244cdc6d3b7733)

Change-Id: I9b7ea859889b7697bee4165a2746602212120543
(cherry picked from commit 5d17838adef13062717322e79d4db0b9bb6b2395)
